### PR TITLE
Add glibc 2.27 compatibility

### DIFF
--- a/src/Dataflow/Modules/Visualization/GenerateStreamLinesWithPlacementHeuristic.cc
+++ b/src/Dataflow/Modules/Visualization/GenerateStreamLinesWithPlacementHeuristic.cc
@@ -197,7 +197,7 @@ execute(GenerateStreamLinesWithPlacementHeuristicData &MESL, ProgressReporter * 
   for(int i=0; i<numsl; i++) 
   {
     mod->remark("streamline: "+to_string(i));
-    rmsmin=HUGE;
+    rmsmin=std::numeric_limits<int>::max();
     bool found=false;
     FieldHandle mslminH;
 


### PR DESCRIPTION
Starting with glibc 2.27, support for SVID error handling has been removed, including the corresponding constants.